### PR TITLE
ci: upgrade to Java 25 and modernize Gradle action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Set up JDK 11
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '25-ea'
+        distribution: 'temurin'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1
-      with:
-        arguments: build
+      uses: gradle/actions/setup-gradle@v4
+    - name: Run build
+      run: ./gradlew build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrade JDK from 11 to 25 (early access, temurin)
- Replace deprecated `gradle/gradle-build-action` with `gradle/actions/setup-gradle@v4`
- Switch distribution from `adopt` to `temurin`
- Unblocks Gradle 9.x wrapper update (#71)